### PR TITLE
ChainService logic for logs extraction added

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+.dfx/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -60,32 +60,36 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "candid"
-version = "0.10.10"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c30ee7f886f296b6422c0ff017e89dd4f831521dfdcc76f3f71aae1ce817222"
+checksum = "465c1ce01d8089ee5b49ba20d3a9da15a28bba64c35cdff2aa256d37e319625d"
 dependencies = [
  "anyhow",
  "binread",
  "byteorder",
  "candid_derive",
+ "codespan-reporting",
+ "crc32fast",
+ "data-encoding",
  "hex",
- "ic_principal",
  "leb128",
  "num-bigint",
  "num-traits",
+ "num_enum",
  "paste",
  "pretty",
  "serde",
  "serde_bytes",
+ "sha2",
  "stacker",
  "thiserror",
 ]
 
 [[package]]
 name = "candid_derive"
-version = "0.6.6"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3de398570c386726e7a59d9887b68763c481477f9a043fb998a2e09d428df1a9"
+checksum = "201ea498d901add0822653ac94cb0f8a92f9b1758a5273f4dafbb6673c9a5020"
 dependencies = [
  "lazy_static",
  "proc-macro2",
@@ -107,6 +111,16 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "codespan-reporting"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e"
+dependencies = [
+ "termcolor",
+ "unicode-width",
+]
 
 [[package]]
 name = "cpufeatures"
@@ -159,14 +173,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 
 [[package]]
+name = "equivalent"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+
+[[package]]
 name = "evm-logs-canister"
 version = "0.1.0"
 dependencies = [
  "candid",
+ "evm_rpc_types",
  "ic-cdk",
- "ic-cdk-macros 0.9.0",
+ "ic-cdk-macros",
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "evm_rpc_types"
+version = "0.1.0"
+source = "git+https://github.com/internet-computer-protocol/evm-rpc-canister#bbd7046613a268416ebe91b7681975acd5ad388a"
+dependencies = [
+ "candid",
+ "hex",
+ "ic-cdk",
+ "num-bigint",
+ "serde",
 ]
 
 [[package]]
@@ -180,6 +213,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+
+[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -187,12 +226,12 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "ic-cdk"
-version = "0.16.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd8ecacd682fa05a985253592963306cb9799622d7b1cce4b1edb89c6ec85be1"
+checksum = "6760cfb714f1ef4bd7a8d3d848306b70949c147e16b29b751965f869c0e88730"
 dependencies = [
  "candid",
- "ic-cdk-macros 0.16.0",
+ "ic-cdk-macros",
  "ic0",
  "serde",
  "serde_bytes",
@@ -200,49 +239,32 @@ dependencies = [
 
 [[package]]
 name = "ic-cdk-macros"
-version = "0.9.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fde5ca6ef1e69825c68916ff1bf7256b8f7ed69ac5ea3f1756f6e57f1503e27"
+checksum = "411c0dd4c149132b68e679274d397053332ee29996c6a541075895881916333b"
 dependencies = [
  "candid",
  "proc-macro2",
  "quote",
  "serde",
- "serde_tokenstream 0.1.7",
+ "serde_tokenstream",
  "syn 1.0.109",
 ]
 
 [[package]]
-name = "ic-cdk-macros"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d4d857135deef20cc7ea8f3869a30cd9cfeb1392b3a81043790b2cd82adc3e0"
-dependencies = [
- "candid",
- "proc-macro2",
- "quote",
- "serde",
- "serde_tokenstream 0.2.2",
- "syn 2.0.77",
-]
-
-[[package]]
 name = "ic0"
-version = "0.23.0"
+version = "0.18.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8de254dd67bbd58073e23dc1c8553ba12fa1dc610a19de94ad2bbcd0460c067f"
+checksum = "576c539151d4769fb4d1a0c25c4108dd18facd04c5695b02cf2d226ab4e43aa5"
 
 [[package]]
-name = "ic_principal"
-version = "0.1.1"
+name = "indexmap"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1762deb6f7c8d8c2bdee4b6c5a47b60195b74e9b5280faa5ba29692f8e17429c"
+checksum = "68b900aa2f7301e21c36462b170ee99994de34dff39a4a6a528e80e7376d07e5"
 dependencies = [
- "crc32fast",
- "data-encoding",
- "serde",
- "sha2",
- "thiserror",
+ "equivalent",
+ "hashbrown",
 ]
 
 [[package]]
@@ -305,6 +327,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_enum"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a015b430d3c108a207fd776d2e2196aaf8b1cf8cf93253e3a097ff3085076a1"
+dependencies = [
+ "num_enum_derive",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96667db765a921f7b295ffee8b60472b686a51d4f21c2ee4ffdb94c7013b65a6"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.77",
+]
+
+[[package]]
+name = "once_cell"
+version = "1.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+
+[[package]]
 name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -319,6 +368,16 @@ dependencies = [
  "arrayvec",
  "typed-arena",
  "unicode-width",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f4c021e1093a56626774e81216a4ce732a735e5bad4868a03f3ed65ca0c3919"
+dependencies = [
+ "once_cell",
+ "toml_edit",
 ]
 
 [[package]]
@@ -413,18 +472,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_tokenstream"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64060d864397305347a78851c51588fd283767e7e7589829e8121d65512340f1"
-dependencies = [
- "proc-macro2",
- "quote",
- "serde",
- "syn 2.0.77",
-]
-
-[[package]]
 name = "sha2"
 version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -477,6 +524,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "termcolor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "thiserror"
 version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -494,6 +550,23 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.77",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
+
+[[package]]
+name = "toml_edit"
+version = "0.19.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
+dependencies = [
+ "indexmap",
+ "toml_datetime",
+ "winnow",
 ]
 
 [[package]]
@@ -525,6 +598,15 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
+dependencies = [
+ "windows-sys",
+]
 
 [[package]]
 name = "windows-sys"
@@ -598,3 +680,12 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "winnow"
+version = "0.5.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
+dependencies = [
+ "memchr",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,11 +7,13 @@ edition = "2021"
 crate-type = ["cdylib"]
 
 [dependencies]
-candid = { version = "0.10.10" }
-ic-cdk = "0.16.0"
-ic-cdk-macros = "0.9"
+candid = { version = "0.9" }
+ic-cdk = "0.10.0"
+ic-cdk-macros = "0.7"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+evm_rpc_types = { git = "https://github.com/internet-computer-protocol/evm-rpc-canister", package = "evm_rpc_types" }
+
 
 
 [package.metadata.candid]

--- a/dfx.json
+++ b/dfx.json
@@ -5,6 +5,17 @@
         "wasm": "target/wasm32-unknown-unknown/release/evm_logs_canister.wasm",
         "candid": "src/evm_logs_canister.did",
         "build": "cargo build --target wasm32-unknown-unknown --release"
+      },
+      "evm_rpc": {
+        "type": "custom",
+        "candid": "https://github.com/internet-computer-protocol/evm-rpc-canister/releases/latest/download/evm_rpc.did",
+        "wasm": "https://github.com/internet-computer-protocol/evm-rpc-canister/releases/latest/download/evm_rpc.wasm.gz",
+        "remote": {
+          "id": {
+            "ic": "7hfb6-caaaa-aaaar-qadga-cai"
+          }
+        },
+        "init_arg": "(record {})"
       }
     },
     "networks": {

--- a/dfx.json
+++ b/dfx.json
@@ -1,29 +1,34 @@
 {
-    "canisters": {
-      "evm_logs_canister": {
-        "type": "custom",
-        "wasm": "target/wasm32-unknown-unknown/release/evm_logs_canister.wasm",
-        "candid": "src/evm_logs_canister.did",
-        "build": "cargo build --target wasm32-unknown-unknown --release"
+  "canisters": {
+    "evm_logs_canister": {
+      "type": "custom",
+      "wasm": "target/wasm32-unknown-unknown/release/evm_logs_canister.wasm",
+      "candid": "src/evm_logs_canister.did",
+      "build": "cargo build --target wasm32-unknown-unknown --release",
+      "metadata": [
+        {
+          "name": "candid:service",
+          "value": "src/evm_logs_canister.did"
+        }
+      ]
+    },
+    "evm_rpc": {
+      "type": "custom",
+      "candid": "https://github.com/internet-computer-protocol/evm-rpc-canister/releases/latest/download/evm_rpc.did",
+      "wasm": "https://github.com/internet-computer-protocol/evm-rpc-canister/releases/latest/download/evm_rpc.wasm.gz",
+      "remote": {
+        "id": {
+          "ic": "7hfb6-caaaa-aaaar-qadga-cai"
+        }
       },
-      "evm_rpc": {
-        "type": "custom",
-        "candid": "https://github.com/internet-computer-protocol/evm-rpc-canister/releases/latest/download/evm_rpc.did",
-        "wasm": "https://github.com/internet-computer-protocol/evm-rpc-canister/releases/latest/download/evm_rpc.wasm.gz",
-        "remote": {
-          "id": {
-            "ic": "7hfb6-caaaa-aaaar-qadga-cai"
-          }
-        },
-        "init_arg": "(record {})"
-      }
-    },
-    "networks": {
-      "local": {
-        "bind": "127.0.0.1:8000",
-        "type": "ephemeral"
-      }
-    },
-    "version": 1
-  }
-  
+      "init_arg": "(record {nodesInSubnet=12})"
+    }
+  },
+  "networks": {
+    "local": {
+      "bind": "127.0.0.1:8000",
+      "type": "ephemeral"
+    }
+  },
+  "version": 1
+}

--- a/src/chain_service.rs
+++ b/src/chain_service.rs
@@ -1,10 +1,72 @@
+use candid::{CandidType, Deserialize, Nat};
 use ic_cdk::api::call::call;
 use candid::Principal; // Імпорт для Principal
 use std::cell::RefCell;
+use std::io::{self, Write};
+use candid::Encode;
+
+
+// All there structs are to be removed after exporting evm-epc-types crate to the project 
+#[derive(CandidType, Deserialize, Debug)]
+enum EthMainnetService {
+    Cloudflare,
+}
+
+#[derive(CandidType, Deserialize, Debug)]
+enum BlockTag {
+    Number(Nat),
+}
+
+#[derive(CandidType, Deserialize, Debug)]
+struct GetLogsArgs {
+    from_block: Option<BlockTag>,
+    to_block: Option<BlockTag>,
+    addresses: Vec<String>,
+    topics: Option<Vec<Vec<String>>>,
+}
+
+#[derive(CandidType, Deserialize, Debug)]
+struct RpcConfig {
+    responseSizeEstimate: Option<Nat>,
+}
 
 pub struct ChainService {
-    canister_id: String, // ID каністри EVM RPC
+    canister_id: String, 
 }
+
+#[derive(CandidType, Deserialize, Debug)]
+struct RpcError {
+    code: i64,
+    message: String,
+}
+
+#[derive(CandidType, Deserialize, Debug)]
+struct LogEntry {
+    transactionHash: Option<String>,
+    blockNumber: Option<Nat>,
+    data: String,
+    topics: Vec<String>,
+    address: String,
+    logIndex: Option<Nat>,
+}
+
+#[derive(CandidType, Deserialize, Debug)]
+enum GetLogsResult {
+    Ok(Vec<LogEntry>),
+    Err(RpcError),
+}
+
+#[derive(CandidType, Deserialize, Debug)]
+enum RpcServices {
+    EthMainnet(Option<Vec<EthMainnetService>>),
+}
+
+#[derive(CandidType, Deserialize, Debug)]
+enum MultiGetLogsResult {
+    Consistent(GetLogsResult),
+    Inconsistent(Vec<(RpcServices, GetLogsResult)>),
+}
+
 
 impl ChainService {
     pub fn new(canister_id: String) -> Self {
@@ -12,42 +74,47 @@ impl ChainService {
     }
 
     pub async fn fetch_logs(&self, from_block: u64, to_block: u64, address: Option<String>) -> Result<Vec<String>, String> {
-        let method = "eth_getLogs";
-        let params = if let Some(addr) = address {
-            format!(
-                "[{{\"fromBlock\": \"0x{:x}\", \"toBlock\": \"0x{:x}\", \"address\": \"{}\"}}]",
-                from_block, to_block, addr
-            )
-        } else {
-            format!(
-                "[{{\"fromBlock\": \"0x{:x}\", \"toBlock\": \"0x{:x}\"}}]",
-                from_block, to_block
-            )
+        let canister_id = Principal::from_text(&self.canister_id)
+            .map_err(|e| format!("Invalid canister ID: {:?}", e))?;
+    
+        // RpcServices: EthMainnet з Cloudflare
+        let rpc_services = RpcServices::EthMainnet(Some(vec![EthMainnetService::Cloudflare]));
+    
+        let get_logs_args = GetLogsArgs {
+            from_block: Some(BlockTag::Number(Nat::from(from_block))),
+            to_block: Some(BlockTag::Number(Nat::from(to_block))),
+            addresses: match address {
+                Some(addr) => vec![addr],
+                None => vec![],
+            },
+            topics: None,
         };
 
-        let json_rpc_request = format!(
-            "{{\"jsonrpc\": \"2.0\", \"method\": \"{}\", \"params\": {}, \"id\": 1}}",
-            method, params
-        );
+        let rpc_config: Option<RpcConfig> = None; 
 
-        // String => Principal
-        let principal_id = Principal::from_text(&self.canister_id).map_err(|e| format!("Invalid canister ID: {:?}", e))?;
+        let result: Result<(MultiGetLogsResult,), _> = call(
+            canister_id, 
+            "eth_getLogs", 
+            (rpc_services, rpc_config, get_logs_args)
+        ).await;
 
-        // Call EVM RPC canister
-        let result: Result<(String,), _> = call(
-            principal_id,
-            "request",
-            (("variant {Chain=0x1}".to_string(), json_rpc_request, 1000),),
-        )
-        .await;
-
-        // Process result
         match result {
-            Ok((response,)) => {
-                Ok(vec![response])
-            }
-            Err(err) => Err(format!("Error fetching logs: {:?}", err)),
+            Ok((multi_get_logs_result,)) => {
+                match multi_get_logs_result {
+                    MultiGetLogsResult::Consistent(GetLogsResult::Ok(log_entries)) => {
+                        let logs: Vec<String> = log_entries.into_iter().map(|entry| entry.data).collect();
+                        Ok(logs)
+                    },
+                    MultiGetLogsResult::Consistent(GetLogsResult::Err(rpc_error)) => {
+                        Err(format!("RPC Error: Code: {}, Message: {}", rpc_error.code, rpc_error.message))
+                    },
+                    MultiGetLogsResult::Inconsistent(_) => {
+                        Err("Inconsistent logs found.".to_string())
+                    }
+                }
+            },
+            Err(err) => Err(format!("Error calling canister: {:?}", err)),
         }
-
     }
+    
 }

--- a/src/chain_service.rs
+++ b/src/chain_service.rs
@@ -1,0 +1,53 @@
+use ic_cdk::api::call::call;
+use candid::Principal; // Імпорт для Principal
+use std::cell::RefCell;
+
+pub struct ChainService {
+    canister_id: String, // ID каністри EVM RPC
+}
+
+impl ChainService {
+    pub fn new(canister_id: String) -> Self {
+        ChainService { canister_id }
+    }
+
+    pub async fn fetch_logs(&self, from_block: u64, to_block: u64, address: Option<String>) -> Result<Vec<String>, String> {
+        let method = "eth_getLogs";
+        let params = if let Some(addr) = address {
+            format!(
+                "[{{\"fromBlock\": \"0x{:x}\", \"toBlock\": \"0x{:x}\", \"address\": \"{}\"}}]",
+                from_block, to_block, addr
+            )
+        } else {
+            format!(
+                "[{{\"fromBlock\": \"0x{:x}\", \"toBlock\": \"0x{:x}\"}}]",
+                from_block, to_block
+            )
+        };
+
+        let json_rpc_request = format!(
+            "{{\"jsonrpc\": \"2.0\", \"method\": \"{}\", \"params\": {}, \"id\": 1}}",
+            method, params
+        );
+
+        // String => Principal
+        let principal_id = Principal::from_text(&self.canister_id).map_err(|e| format!("Invalid canister ID: {:?}", e))?;
+
+        // Call EVM RPC canister
+        let result: Result<(String,), _> = call(
+            principal_id,
+            "request",
+            (("variant {Chain=0x1}".to_string(), json_rpc_request, 1000),),
+        )
+        .await;
+
+        // Process result
+        match result {
+            Ok((response,)) => {
+                Ok(vec![response])
+            }
+            Err(err) => Err(format!("Error fetching logs: {:?}", err)),
+        }
+
+    }
+}

--- a/src/evm_logs_canister.did
+++ b/src/evm_logs_canister.did
@@ -137,4 +137,5 @@ service : {
   call_confirm_messages : (vec nat) -> (ConfirmationResult);
   icrc72_handle_notification : (EventNotification) -> ();
   icrc72_get_subscriptions : (namespace : opt text, prev : opt nat, take : opt nat64, stats_filter : opt vec ICRC16Map) -> (vec SubscriptionInfo) query;
+  get_chain_events : () -> (vec text);
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -110,8 +110,8 @@ fn call_get_subscriptions(
 #[update]
 #[candid_method(update)]
 async fn get_chain_events() -> Vec<String> {
-    let chain_service = ChainService::new("7hfb6-caaaa-aaaar-qadga-cai".to_string());
-    let logs_result = chain_service.fetch_logs(199, 200, None).await;
+    let chain_service = ChainService::new("be2us-64aaa-aaaaa-qaabq-cai".to_string());
+    let logs_result = chain_service.fetch_logs(100, 200, Some("0x2170Ed0880ac9A755fd29B2688956BD959F933F8".to_string())).await;
 
     match logs_result {
         Ok(logs) => logs,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -104,14 +104,12 @@ fn call_get_subscriptions(
     subscription_manager::get_subscriptions_info(namespace, prev, take, stats_filter)
 }
 
-
-
 // ChainService: get EVM logs
 #[update]
 #[candid_method(update)]
 async fn get_chain_events() -> Vec<String> {
-    let chain_service = ChainService::new("be2us-64aaa-aaaaa-qaabq-cai".to_string());
-    let logs_result = chain_service.fetch_logs(100, 200, Some("0x2170Ed0880ac9A755fd29B2688956BD959F933F8".to_string())).await;
+    let chain_service = ChainService::new("bd3sg-teaaa-aaaaa-qaaba-cai".to_string());
+    let logs_result = chain_service.fetch_logs(20697988, 20697990, Some("0xde0B295669a9FD93d5F28D9Ec85E40f4cb697BAe".to_string())).await;
 
     match logs_result {
         Ok(logs) => logs,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@
 mod types;
 mod utils;
 mod subscription_manager;
+mod chain_service; 
 
 use ic_cdk_macros::*;
 use candid::candid_method;
@@ -11,13 +12,23 @@ use crate::types::*;
 
 use candid::Nat;
 use ic_cdk_macros::query;
+use chain_service::ChainService;
+use std::cell::RefCell;
 
+
+thread_local! {
+    static CHAIN_SERVICE: RefCell<Option<ChainService>> = RefCell::new(None);
+}
 
 // canister init and update
 
 #[init]
 fn init() {
     subscription_manager::init();
+
+    CHAIN_SERVICE.with(|cs| {
+        *cs.borrow_mut() = Some(ChainService::new("https://rpc-url".to_string()));
+    });
 }
 
 #[pre_upgrade]
@@ -28,6 +39,9 @@ fn pre_upgrade() {
 #[post_upgrade]
 fn post_upgrade() {
     subscription_manager::post_upgrade();
+    CHAIN_SERVICE.with(|cs| {
+        *cs.borrow_mut() = Some(ChainService::new("https://rpc-url".to_string()));
+    });
 }
 
 // Orchestrator export 
@@ -88,6 +102,21 @@ fn call_get_subscriptions(
     stats_filter: Option<Vec<ICRC16Map>>,
 ) -> Vec<SubscriptionInfo> {
     subscription_manager::get_subscriptions_info(namespace, prev, take, stats_filter)
+}
+
+
+
+// ChainService: get EVM logs
+#[update]
+#[candid_method(update)]
+async fn get_chain_events() -> Vec<String> {
+    let chain_service = ChainService::new("7hfb6-caaaa-aaaar-qadga-cai".to_string());
+    let logs_result = chain_service.fetch_logs(199, 200, None).await;
+
+    match logs_result {
+        Ok(logs) => logs,
+        Err(err) => vec![format!("{}", err)],
+    }
 }
 
 


### PR DESCRIPTION
Added basic logic for the ChainService component, which is responsible for extracting logs from the EVM using the [evm-rpc-canister](https://github.com/internet-computer-protocol/evm-rpc-canister/). 
At this stage, the focus is on basic log extraction functionality, with no filters or additional logic implemented yet.