### PR TITLE
Filter by topics feature implemented

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 #!/usr/bin/make
 POCKET_IC_BIN := ./pocket-ic
 EVM_LOGS_CANISTER_WASM := ./target/wasm32-unknown-unknown/release/evm_logs_canister.wasm
-TEST_CANISTER_WASM := ./target/wasm32-unknown-unknown/release/test_canister.wasm
+TEST_CANISTER_WASM := ./target/wasm32-unknown-unknown/release/test_canister1.wasm
 .DEFAULT_GOAL: help
 
 .PHONY: help

--- a/README.md
+++ b/README.md
@@ -71,22 +71,37 @@ Notes:
 You can subscribe on the evm_logs_canister from another canister by specifying your filter(test_canister already built and deployed by the build scipt for demonstration):
 
 ```
-dfx canister call test_canister2 register_subscription '(
-    principal "bkyz2-fmaaa-aaaaa-qaaaq-cai",
-    vec {
-        record {
-            namespace = "com.events.Ethereum";
-            filters = vec {
-                record {
-                    addresses = vec { "0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84" };
-                    topics = null;
-                };
-            };
-            memo = null;
-        };
-    }
-)'
+  dfx canister call test_canister1 register_subscription '(
+      principal "bkyz2-fmaaa-aaaaa-qaaaq-cai",
+      vec {
+          record {
+              namespace = "com.events.Ethereum";
+              filters = vec {
+                  record {
+                      addresses = vec { "0x0d4a11d5EEaaC28EC3F61d100daF4d40471f1852" };
+                      topics = opt vec {
+                        vec { "0xd78ad95fa46c994b6551d0da85fc275fe613ce37657fb8d5e3d130840159d822" };
+                        vec { "0x0000000000000000000000003fc91a3afd70395cd496c647d5a6cc9d4b2b7fad" };
+                      };
+                  };
+              };
+              
+              memo = null;
+          };
+      }
+  )'
 ```
+
+#### Strategy of EVM Topics Passing:
+When sending a filter to the EVM node, you can specify which log topics should match specific positions in the event. Here’s how the topic filters work:
+
+- [] (empty): Matches any transaction, as no specific topics are required.
+- [A]: Matches if the first topic of the transaction is A, with no restrictions on the following topics.
+- [null, B]: Matches any transaction with B in the second position, regardless of the first topic.
+- [A, B]: Matches transactions where A is in the first position and B is in the second.
+- [[A, B], [A, B]]: Matches if the first topic is either A or B, and the second topic is also either A or B. This creates an "OR" condition for each position.
+
+This strategy provides flexibility in filtering specific transactions based on topic order and values.
 
 ### Get your active subscriptions with IDs
 

--- a/evm_logs_types/src/pub_sub/mod.rs
+++ b/evm_logs_types/src/pub_sub/mod.rs
@@ -55,6 +55,13 @@ pub struct SubscriptionInfo {
     pub stats: Vec<ICRC16Map>,
 }
 
+#[derive(Clone, Debug)]
+pub enum ChainName {
+    Ethereum,
+    Base,
+    Optimism,
+}
+
 #[derive(CandidType, Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct Filter {
     pub addresses: Vec<String>,
@@ -69,31 +76,38 @@ pub struct Skip {
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub enum ICRC16Value {
-    Array(Vec<ICRC16Value>),
-    Blob(Vec<u8>),
     Bool(bool),
     Bytes(Vec<u8>),
-    Class(Vec<ICRC16Property>),
     Float(f64),
-    Floats(Vec<f64>),
-    Int(i128),
-    Int16(i16),
-    Int32(i32),
-    Int64(i64),
-    Int8(i8),
     Map(Vec<ICRC16Map>),
-    ValueMap(Vec<ICRC16ValueMap>),
     Nat(u128),
-    Nat16(u16),
-    Nat32(u32),
-    Nat64(u64),
-    Nat8(u8),
-    Nats(Vec<u128>),
-    Option(Box<ICRC16Value>),
     Principal(Principal),
-    Set(Vec<ICRC16Value>),
     Text(String),
 }
+
+impl TryFrom<ICRC16Value> for Vec<u8> {
+    type Error = &'static str;
+
+    fn try_from(value: ICRC16Value) -> Result<Self, Self::Error> {
+        match value {
+            ICRC16Value::Text(text) => Ok(text.into_bytes()),
+            _ => Err("Cannot convert non-text value to Vec<u8>"),
+        }
+    }
+}
+
+// experimental
+impl TryFrom<ICRC16Value> for String{
+    type Error = &'static str;
+
+    fn try_from(value: ICRC16Value) -> Result<Self, Self::Error> {
+        match value {
+            ICRC16Value::Text(text) => Ok(text),
+            _ => Err("Cannot convert non-text value to String"),
+        }
+    }
+}
+
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct ICRC16Property {

--- a/src/evm_logs_canister.did
+++ b/src/evm_logs_canister.did
@@ -113,6 +113,12 @@ type UnsubscribeResult = variant {
     Err : text;
 };
 
+type PublishError = variant {
+  Unauthorized : null;
+  ImproperId : text;
+  Busy : null;
+  GenericError : GenericError;
+};
 
 service : {
   register_subscription : (vec SubscriptionRegistration) -> (vec RegisterSubscriptionResult);
@@ -121,4 +127,5 @@ service : {
   get_user_subscriptions : () -> (vec SubscriptionInfo) query;
   get_active_filters: () -> (vec Filter) query;
   get_active_addresses_and_topics: () -> (vec text, opt vec vec text) query;
+  icrc72_publish : (vec Event) -> (vec opt variant { Ok : vec nat; Err : PublishError });
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,17 +32,17 @@ async fn init() {
 
     let chain_configs = vec![
         ChainConfig {
-            chain_name: "Ethereum".to_string(),
+            chain_name: ChainName::Ethereum,
             rpc_providers: RpcServices::EthMainnet(Some(vec![EthMainnetService::Alchemy])),
             evm_rpc_canister: Principal::from_text("bd3sg-teaaa-aaaaa-qaaba-cai").unwrap(),
         },
         ChainConfig {
-            chain_name: "Base".to_string(),
+            chain_name: ChainName::Base,
             rpc_providers: RpcServices::BaseMainnet(Some(vec![L2MainnetService::PublicNode])),
             evm_rpc_canister: Principal::from_text("bd3sg-teaaa-aaaaa-qaaba-cai").unwrap(),
         },
         ChainConfig {
-            chain_name: "Optimism".to_string(),
+            chain_name: ChainName::Optimism,
             rpc_providers: RpcServices::OptimismMainnet(Some(vec![L2MainnetService::PublicNode])),
             evm_rpc_canister: Principal::from_text("bd3sg-teaaa-aaaaa-qaaba-cai").unwrap(),
         },

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@
 mod utils;
 mod subscription_manager;
 mod chain_service;
+mod topic_manager;
 
 use ic_cdk_macros::*;
 use candid::candid_method;
@@ -118,6 +119,16 @@ fn get_subscriptions(
     filters: Option<Vec<Filter>>,
 ) -> Vec<SubscriptionInfo> {
     subscription_manager::get_subscriptions_info(namespace, from_id, filters)
+}
+
+
+// only testing purpose
+#[update(name = "publish_events")]
+#[candid_method(update)]
+async fn icrc72_publish(
+    events: Vec<Event>,
+) -> Vec<Option<Result<Vec<Nat>, PublishError>>> {
+    subscription_manager::publish_events(events).await
 }
 
 #[query]

--- a/src/subscription_manager.rs
+++ b/src/subscription_manager.rs
@@ -1,10 +1,12 @@
 use candid::{Principal, Nat};
 use std::{cell::RefCell, collections::HashSet};
 use std::collections::HashMap;
+use crate::topic_manager::TopicManager;
+use crate::utils::event_matches_filter;
 
 use evm_logs_types::{
     SubscriptionInfo, Event, SubscriptionRegistration, RegisterSubscriptionResult, RegisterSubscriptionError,
-    EventNotification, PublishError, Filter, UnsubscribeResult
+    EventNotification, PublishError, Filter, UnsubscribeResult, ICRC16Value
 };
 
 use crate::utils::current_timestamp;
@@ -18,38 +20,16 @@ thread_local! {
     static NEXT_EVENT_ID: RefCell<Nat> = RefCell::new(Nat::from(1u32));
     static NEXT_NOTIFICATION_ID: RefCell<Nat> = RefCell::new(Nat::from(1u32));
 
-    // these fields are for performance optimization. ChainService will directly get these values and pass to evm-rpc-canister
     static ADDRESSES: RefCell<HashMap<String, u64>> = RefCell::new(HashMap::new());
-    static TOPICS: RefCell<HashMap<Vec<Vec<String>>, u64>> = RefCell::new(HashMap::new());
+    
+    static TOPICS_MANAGER: RefCell<TopicManager> = RefCell::new(TopicManager::new());
+
+
 }
 
 pub fn init() {
     ic_cdk::println!("SubscriptionManager initialized");
 }
-
-// #[pre_upgrade]
-// pub fn pre_upgrade() {
-//     let publications = PUBLICATIONS.with(|pubs| pubs.borrow().clone());
-//     let subscriptions = SUBSCRIPTIONS.with(|subs| subs.borrow().clone());
-//     let events = EVENTS.with(|evs| evs.borrow().clone());
-
-//     ic_cdk::storage::stable_save((publications, subscriptions, events))
-//         .expect("Failed to save stable state");
-// }
-
-// #[post_upgrade]
-// pub fn post_upgrade() {
-//     let (saved_publications, saved_subscriptions, saved_events): (
-//         HashMap<Nat, PublicationInfo>,
-//         HashMap<Nat, SubscriptionInfo>,
-//         HashMap<Nat, Event>,
-//     ) = ic_cdk::storage::stable_restore().expect("Failed to restore stable state");
-
-//     PUBLICATIONS.with(|pubs| *pubs.borrow_mut() = saved_publications);
-//     SUBSCRIPTIONS.with(|subs| *subs.borrow_mut() = saved_subscriptions);
-//     EVENTS.with(|evs| *evs.borrow_mut() = saved_events);
-// }
-
 
 pub async fn register_subscription(
     registrations: Vec<SubscriptionRegistration>,
@@ -111,17 +91,15 @@ pub async fn register_subscription(
             }
         });
 
-        TOPICS.with(|topic_map| {
-            let mut topic_count_map = topic_map.borrow_mut();
-            
+        TOPICS_MANAGER.with(|manager| {
+            let mut manager = manager.borrow_mut();
             for filter in &filters {
-                if let Some(filter_topics) = &filter.topics {
-                    *topic_count_map.entry(filter_topics.clone()).or_insert(0) += 1;
-                }
+                manager.add_filter(&filter.topics);
             }
-
+            ic_cdk::println!("TOPICS MANAGER: {:?}", manager.subscriptions_accept_any_topic_at_position);
         });
-
+        
+        
         
         SUBSCRIPTIONS.with(|subs| {
             subs.borrow_mut().insert(sub_id.clone(), subscription_info);
@@ -146,6 +124,9 @@ pub async fn register_subscription(
 
     results
 }
+
+
+
 
 pub async fn publish_events(
     events: Vec<Event>,
@@ -248,20 +229,6 @@ async fn distribute_event(event: Event) {
     }
 }
 
-// Function to check if the event matches the subscriber's filter
-fn event_matches_filter(event: &Event, subscribers_filter: &Filter) -> bool {
-    let event_address = event.address.trim().to_lowercase();
-
-    if subscribers_filter.addresses.iter().any(|address| { address.trim().to_lowercase() == event_address}) {
-        return true;
-    }
-
-    // TODO TOPICS CHECK
-
-    false
-}
-
-
 pub fn get_subscriptions_info(
     namespace: Option<String>,
     from_id: Option<Nat>,
@@ -305,26 +272,15 @@ pub fn get_active_filters() -> Vec<Filter> {
 // Get unique addresses and topics to pass to eth_getLogs.
 pub fn get_active_addresses_and_topics() -> (Vec<String>, Option<Vec<Vec<String>>>) {
     let addresses: Vec<String> = ADDRESSES.with(|addr| {
-        addr.borrow().keys().cloned().collect() 
+        addr.borrow().keys().cloned().collect()
     });
 
-    let topics: Option<Vec<Vec<String>>> = TOPICS.with(|tpc| {
-        let mut all_topics: Vec<Vec<String>> = vec![]; 
-    
-        for topic_vec in tpc.borrow().keys() {
-            all_topics.extend(topic_vec.clone());  
-        }
-    
-        if all_topics.is_empty() {
-            None
-        } else {
-            Some(all_topics)  
-        }
+    let topics = TOPICS_MANAGER.with(|manager| {
+        manager.borrow().get_combined_topics()
     });
 
     (addresses, topics)
 }
-
 
 
 
@@ -368,17 +324,10 @@ pub fn unsubscribe(caller: Principal, subscription_id: Nat) -> UnsubscribeResult
             }
         });
 
-        TOPICS.with(|topic_map| {
-            let mut topic_count_map = topic_map.borrow_mut();
+        TOPICS_MANAGER.with(|manager| {
+            let mut manager = manager.borrow_mut();
             for filter in &filters {
-                if let Some(filter_topics) = &filter.topics {
-                        if let Some(count) = topic_count_map.get_mut(filter_topics) {
-                            *count -= 1;
-                            if *count == 0 {
-                                topic_count_map.remove(filter_topics);  
-                            }
-                        }
-                }
+                manager.remove_filter(&filter.topics);
             }
         });
 
@@ -397,6 +346,8 @@ pub fn unsubscribe(caller: Principal, subscription_id: Nat) -> UnsubscribeResult
         UnsubscribeResult::Err(format!("Subscription with ID {} not found", subscription_id))
     }
 }
+
+
 
 
 

--- a/src/test_canister1/src/lib.rs
+++ b/src/test_canister1/src/lib.rs
@@ -4,6 +4,8 @@ use ic_cdk_macros::{update, query, init};
 use std::cell::RefCell;
 use evm_logs_types::{SubscriptionRegistration, RegisterSubscriptionResult, EventNotification, UnsubscribeResult};
 
+
+
 thread_local! {
     static NOTIFICATIONS: RefCell<Vec<EventNotification>> = RefCell::new(Vec::new());
 }
@@ -41,6 +43,9 @@ async fn register_subscription(canister_id: Principal, registrations: Vec<Subscr
 async fn icrc72_handle_notification(notification: EventNotification) {
     ic_cdk::println!("Received notification for event ID: {:?}", notification.event_id);
     ic_cdk::println!("Notification details: {:?}", notification);
+
+    // let data = String::try_from(notification.clone().data).expect("Failed to convert ICRC16Value to String");
+    // println!("{}", data);
 
     NOTIFICATIONS.with(|notifs| {
         notifs.borrow_mut().push(notification);
@@ -107,3 +112,4 @@ fn get_candid_pointer() -> String {
 }
 
 candid::export_service!();
+

--- a/src/topic_manager.rs
+++ b/src/topic_manager.rs
@@ -1,0 +1,119 @@
+use std::collections::{HashMap, HashSet};
+use candid::Nat;
+
+pub struct TopicManager {
+    topics: Vec<HashSet<String>>,               
+    topic_counts: Vec<HashMap<String, Nat>>,    
+    pub subscriptions_accept_any_topic_at_position: Vec<Nat>, 
+    total_subscriptions: Nat,                   
+}
+
+impl TopicManager {
+    pub fn new() -> Self {
+        TopicManager {
+            topics: Vec::new(),
+            topic_counts: Vec::new(),
+            subscriptions_accept_any_topic_at_position: Vec::new(),
+            total_subscriptions: Nat::from(0u32),
+        }
+    }
+
+    pub fn add_filter(&mut self, filter_topics: &Option<Vec<Vec<String>>>) {
+        self.total_subscriptions += Nat::from(1u32);
+    
+        if let Some(filter_topics) = filter_topics {
+            let num_positions = filter_topics.len();
+            for i in 0..4 {
+                while self.topics.len() <= i {
+                    self.topics.push(HashSet::new());
+                    self.topic_counts.push(HashMap::new());
+                    self.subscriptions_accept_any_topic_at_position.push(Nat::from(0u32));
+                }
+    
+                if i < num_positions {
+                    let topics_at_pos = &filter_topics[i];
+                    if topics_at_pos.is_empty() {
+                        self.subscriptions_accept_any_topic_at_position[i] += Nat::from(1u32);
+                    } else {
+                        for topic in topics_at_pos {
+                            self.topics[i].insert(topic.clone());
+                            *self.topic_counts[i].entry(topic.clone()).or_insert(Nat::from(0u32)) += Nat::from(1u32);
+                        }
+                    }
+                } else {
+                    self.subscriptions_accept_any_topic_at_position[i] += Nat::from(1u32);
+                }
+            }
+        } else {
+            for i in 0..4 {
+                while self.subscriptions_accept_any_topic_at_position.len() <= i {
+                    self.subscriptions_accept_any_topic_at_position.push(Nat::from(0u32));
+                }
+                self.subscriptions_accept_any_topic_at_position[i] += Nat::from(1u32);
+            }
+        }
+    }
+    
+
+    pub fn remove_filter(&mut self, filter_topics: &Option<Vec<Vec<String>>>) {
+        if self.total_subscriptions > Nat::from(0u32) {
+            self.total_subscriptions -= Nat::from(1u32);
+        }
+
+        if let Some(filter_topics) = filter_topics {
+            for (i, topics_at_pos) in filter_topics.iter().enumerate() {
+                if topics_at_pos.is_empty() {
+                    if self.subscriptions_accept_any_topic_at_position.len() > i {
+                        if self.subscriptions_accept_any_topic_at_position[i] > Nat::from(0u32) {
+                            self.subscriptions_accept_any_topic_at_position[i] -= Nat::from(1u32);
+                        }
+                    }
+                } else {
+                    for topic in topics_at_pos {
+                        if let Some(count) = self.topic_counts[i].get_mut(topic) {
+                            if *count > Nat::from(0u32) {
+                                *count -= Nat::from(1u32);
+                                if *count == Nat::from(0u32) {
+                                    self.topics[i].remove(topic);
+                                    self.topic_counts[i].remove(topic);
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        } else {
+            for i in 0..self.subscriptions_accept_any_topic_at_position.len() {
+                if self.subscriptions_accept_any_topic_at_position[i] > Nat::from(0u32) {
+                    self.subscriptions_accept_any_topic_at_position[i] -= Nat::from(1u32);
+                }
+            }
+        }
+    }
+
+    pub fn get_combined_topics(&self) -> Option<Vec<Vec<String>>> {
+        let mut combined_topics = Vec::new();
+        let mut include_positions = true;
+
+        for i in 0..self.topics.len() {
+            if self.subscriptions_accept_any_topic_at_position.len() > i &&
+               self.subscriptions_accept_any_topic_at_position[i] > Nat::from(0u32) {
+                include_positions = false;
+                break;
+            } else if !self.topics[i].is_empty() {
+                combined_topics.push(self.topics[i].iter().cloned().collect());
+            } else {
+                include_positions = false;
+                break;
+            }
+        }
+
+        if include_positions && !combined_topics.is_empty() {
+            Some(combined_topics)
+        } else if !combined_topics.is_empty() {
+            Some(combined_topics)
+        } else {
+            None 
+        }
+    }
+}

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -4,8 +4,9 @@ use candid::Nat;
 use num_traits::ToPrimitive;
 
 use evm_rpc_canister_types::{
-    BlockTag, EvmRpcCanister, GetBlockByNumberResult, MultiGetBlockByNumberResult, RpcServices,
+    BlockTag, EvmRpcCanister, GetBlockByNumberResult, MultiGetBlockByNumberResult, RpcServices
 };
+use evm_logs_types:: {ICRC16Value, Filter, Event};
 
 thread_local! {
     static SUB_ID_COUNTER: RefCell<Nat> = RefCell::new(Nat::from(0u32));
@@ -41,3 +42,146 @@ pub async fn get_latest_block_number(
         }
     }
 }
+
+// Function to check if the event matches the subscriber's filter
+pub fn event_matches_filter(event: &Event, subscribers_filter: &Filter) -> bool {
+    let event_address = event.address.trim().to_lowercase();
+
+    // Check if event address matches any subscriber address
+    if !subscribers_filter
+        .addresses
+        .iter()
+        .any(|address| address.trim().to_lowercase() == event_address)
+    {
+        return false;
+    }
+
+    // If filter doesn't have topics, we match on address alone
+    if subscribers_filter.topics.is_none() {
+        return true;
+    }
+
+    // If no topics in the event but filter has topics, it's not a match
+    if event.topics.is_none() {
+        return false;
+    }
+
+    // Both filter and event have topics, so we need to match them
+    if let (Some(event_topics), Some(filter_topics)) = (&event.topics, &subscribers_filter.topics) {
+        // Ensure there are enough topics in the event to match the filter
+        if event_topics.len() < filter_topics.len() {
+            return false;
+        }
+
+        for (i, filter_topic_set) in filter_topics.iter().enumerate() {
+            if let Some(event_topic) = event_topics.get(i) {
+                let event_topic_trimmed = event_topic.trim().to_lowercase();
+                if !filter_topic_set
+                    .iter()
+                    .any(|filter_topic| filter_topic.trim().to_lowercase() == event_topic_trimmed)
+                {
+                    return false;
+                }
+            } else {
+                // If the event doesn't have enough topics, it doesn't match
+                return false;
+            }
+        }
+    }
+
+    true
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn create_event(address: &str, topics: Option<Vec<&str>>) -> Event {
+        Event {
+            id: Nat::from(1u8),
+            prev_id: None,
+            timestamp: 0,
+            namespace: "namespace".to_string(),
+            data: ICRC16Value::Text("test".to_string()),
+            headers: None,
+            address: address.to_string(),
+            topics: topics.map(|t| t.into_iter().map(|s| s.to_string()).collect()),
+        }
+    }
+
+    fn create_filter(addresses: Vec<&str>, topics: Option<Vec<Vec<&str>>>) -> Filter {
+        Filter {
+            addresses: addresses.into_iter().map(|s| s.to_string()).collect(),
+            topics: topics.map(|ts| {
+                ts.into_iter()
+                    .map(|topic_set| topic_set.into_iter().map(|s| s.to_string()).collect())
+                    .collect()
+            }),
+        }
+    }
+
+    #[test]
+    fn test_event_matches_filter_address_only_match() {
+        let event = create_event("0xabc", None);
+        let filter = create_filter(vec!["0xABC"], None);
+
+        assert!(event_matches_filter(&event, &filter));
+    }
+
+    #[test]
+    fn test_event_matches_filter_address_only_no_match() {
+        let event = create_event("0xdef", None);
+        let filter = create_filter(vec!["0xABC"], None);
+
+        assert!(!event_matches_filter(&event, &filter));
+    }
+
+    #[test]
+    fn test_event_matches_filter_topics_match() {
+        let event = create_event("0xabc", Some(vec!["topic1", "topic2"]));
+        let filter = create_filter(vec!["0xABC"], Some(vec![vec!["topic1"], vec!["topic2"]]));
+
+        assert!(event_matches_filter(&event, &filter));
+    }
+
+    #[test]
+    fn test_event_matches_filter_topics_no_match() {
+        let event = create_event("0xabc", Some(vec!["topic1", "topic3"]));
+        let filter = create_filter(vec!["0xABC"], Some(vec![vec!["topic1"], vec!["topic2"]]));
+
+        assert!(!event_matches_filter(&event, &filter));
+    }
+
+    #[test]
+    fn test_event_matches_filter_topics_partial_match() {
+        let event = create_event("0xabc", Some(vec!["topic1"]));
+        let filter = create_filter(vec!["0xABC"], Some(vec![vec!["topic1", "topic2"]]));
+
+        assert!(event_matches_filter(&event, &filter));
+    }
+
+    #[test]
+    fn test_event_matches_filter_too_few_event_topics() {
+        let event = create_event("0xabc", Some(vec!["topic1"]));
+        let filter = create_filter(vec!["0xABC"], Some(vec![vec!["topic1"], vec!["topic2"]]));
+
+        assert!(!event_matches_filter(&event, &filter));
+    }
+
+    #[test]
+    fn test_event_matches_filter_no_filter_topics() {
+        let event = create_event("0xabc", Some(vec!["topic1", "topic2"]));
+        let filter = create_filter(vec!["0xABC"], None);
+
+        assert!(event_matches_filter(&event, &filter));
+    }
+
+    #[test]
+    fn test_event_matches_filter_no_event_topics() {
+        let event = create_event("0xabc", None);
+        let filter = create_filter(vec!["0xABC"], Some(vec![vec!["topic1"], vec!["topic2"]]));
+
+        assert!(!event_matches_filter(&event, &filter));
+    }
+}
+

--- a/tests/subscription_manager_test.rs
+++ b/tests/subscription_manager_test.rs
@@ -1,723 +1,181 @@
-// use pocket_ic::WasmResult;
-// use pocket_ic::nonblocking::PocketIc;
-// use candid;
-// use tokio::time::sleep;
-// use candid::Principal;
-// use evm_logs_types::{
-//     SubscriptionRegistration, ICRC16Map, Event, EventNotification, ICRC16Value, 
-//     RegisterSubscriptionResult, RegisterPublicationResult, PublicationRegistration
-// };
-// use candid::CandidType;
-// use std::time::Duration;
-// use candid::Nat;
-// use std::collections::HashSet;
-// use serde::{Deserialize, Serialize};
+use pocket_ic::WasmResult;
+use pocket_ic::nonblocking::PocketIc;
+use candid;
+use tokio::time::sleep;
+use candid::Principal;
+use evm_logs_types::{
+    SubscriptionRegistration, Event, EventNotification, ICRC16Value, 
+    RegisterSubscriptionResult, Filter
+};
+use std::time::Duration;
+use candid::Nat;
+
+
+#[tokio::test]
+async fn test_event_publishing_and_notification_delivery() {
+    let pic = PocketIc::new().await;
+
+    let subscription_manager_canister_id = pic.create_canister().await;
+    pic.add_cycles(subscription_manager_canister_id, 2_000_000_000_000).await;
+
+    let subscription_manager_wasm_path = std::env::var("EVM_LOGS_CANISTER_PATH")
+        .expect("EVM_LOGS_CANISTER_PATH must be set");
+    let subscription_manager_wasm_bytes = tokio::fs::read(subscription_manager_wasm_path)
+        .await
+        .expect("Failed to read the subscription manager WASM file");
+    pic.install_canister(
+        subscription_manager_canister_id,
+        subscription_manager_wasm_bytes.to_vec(),
+        vec![],
+        None,
+    )
+    .await;
+
+    // Create the subscriber canister
+    let subscriber_canister_id = pic.create_canister().await;
+    pic.add_cycles(subscriber_canister_id, 2_000_000_000_000).await;
+
+    // Install the subscriber wasm
+    let subscriber_wasm_path = std::env::var("TEST_CANISTER_WASM_PATH")
+        .expect("TEST_CANISTER_WASM_PATH must be set");
+    let subscriber_wasm_bytes = tokio::fs::read(subscriber_wasm_path)
+        .await
+        .expect("Failed to read the subscriber WASM file");
+    pic.install_canister(
+        subscriber_canister_id,
+        subscriber_wasm_bytes.to_vec(),
+        vec![],
+        None,
+    )
+    .await;
+
+    // Register a subscription from the subscriber canister
+    let subscription_registration = SubscriptionRegistration {
+        namespace: "test_namespace".to_string(),
+        filters: vec![
+            Filter {
+                addresses: vec!["0x0d4a11d5EEaaC28EC3F61d100daF4d40471f1852".to_string()],
+                topics: None, 
+            }
+        ],
+        memo: None,
+    };
+
+    let register_subscription_result = pic
+        .update_call(
+            subscription_manager_canister_id,
+            subscriber_canister_id, 
+            "register_subscription",
+            candid::encode_one(vec![subscription_registration.clone()]).unwrap(),
+        )
+        .await;
+
+    // Check the subscription registration result
+    match register_subscription_result {
+        Ok(WasmResult::Reply(data)) => {
+            let decoded_result: Vec<RegisterSubscriptionResult> = candid::decode_one(&data).unwrap();
+            match &decoded_result[0] {
+                RegisterSubscriptionResult::Ok(sub_id) => {
+                    println!("Subscription successfully created, ID: {:?}", sub_id);
+                }
+                RegisterSubscriptionResult::Err(err) => {
+                    panic!("Subscription registration error: {:?}", err);
+                }
+            }
+        }
+        Ok(WasmResult::Reject(err)) => {
+            panic!("Subscription registration rejected: {:?}", err);
+        }
+        Err(e) => {
+            panic!("Subscription registration call error: {:?}", e);
+        }
+    }
+
+    // Register a publication
+    let publisher_principal = Principal::anonymous(); 
+
+    // Publish an event
+    let event = Event {
+        id: Nat::from(0u64), // ID will be assigned by the canister
+        prev_id: None,
+        timestamp: 0,
+        namespace: "test_namespace".to_string(),
+        data: ICRC16Value::Text("Test event data".to_string()),
+        headers: None,
+        address: "0x0d4a11d5EEaaC28EC3F61d100daF4d40471f1852".to_string(), // Example address
+        topics:None // Example topic
+    };
+    let publish_events_result = pic
+        .update_call(
+            subscription_manager_canister_id,
+            publisher_principal,
+            "publish_events",
+            candid::encode_one(vec![event.clone()]).unwrap(),
+        )
+        .await;
+
+    // Check the event publishing result
+    match publish_events_result {
+        Ok(WasmResult::Reply(data)) => {
+            let decoded_results: Vec<Option<Result<Vec<Nat>, String>>> = candid::decode_one(&data).unwrap();
+            match &decoded_results[0] {
+                Some(Ok(event_ids)) => {
+                    println!("Event published successfully, IDs: {:?}", event_ids);
+                    assert_eq!(event_ids.len(), 1, "Expected one event ID");
+                    assert_ne!(event_ids[0], Nat::from(0u32), "Event ID should not be zero");
+                }
+                Some(Err(err)) => {
+                    panic!("Event publish error: {:?}", err);
+                }
+                None => {
+                    panic!("Event publish returned None");
+                }
+            }
+        }
+        Ok(WasmResult::Reject(err)) => {
+            panic!("Event publish rejected: {:?}", err);
+        }
+        Err(e) => {
+            panic!("Event publish call error: {:?}", e);
+        }
+    }
+
+    // Wait for the notification to be sent
+    sleep(Duration::from_millis(500)).await;
+
+    // Query the subscriber canister to retrieve notifications
+    let get_notifications_result = pic
+        .query_call(
+            subscriber_canister_id,
+            Principal::anonymous(),
+            "get_notifications",
+            candid::encode_args(()).unwrap(),
+        )
+        .await;
+
+    // Verify that the subscriber received the notification
+    match get_notifications_result {
+        Ok(WasmResult::Reply(data)) => {
+            let notifications: Vec<EventNotification> = candid::decode_one(&data).unwrap();
+            println!("Received notifications: {:?}", notifications);
+            assert_eq!(notifications.len(), 1, "Expected one notification");
+            let notification = &notifications[0];
+            assert_eq!(notification.namespace, "test_namespace", "Incorrect namespace");
+            assert_eq!(notification.event_id, Nat::from(1u64), "Incorrect event_id");
+            if let ICRC16Value::Text(ref text) = notification.data {
+                assert_eq!(text, "Test event data", "Incorrect event data");
+            } else {
+                panic!("Unexpected data type in notification");
+            }
+            assert!(notification.filter.is_none(), "Expected no filter");
+        }
+        Ok(WasmResult::Reject(err)) => {
+            panic!("Get notifications rejected: {:?}", err);
+        }
+        Err(e) => {
+            panic!("Get notifications call error: {:?}", e);
+        }
+    }
+}
 
 
-// #[derive(CandidType, Clone, Debug, Serialize, Deserialize)]
-// pub struct Filter {
-//     pub addresses: Vec<String>,
-//     pub topics: Option<Vec<Vec<String>>>,
-// }
-
-
-// #[tokio::test]
-// async fn test_register_subscription_with_two_filters() {
-//     println!("Starting test: test_register_subscription_with_two_filters");
-
-//     let pic = PocketIc::new().await;
-
-//     // Create the first canister
-//     let canister_id_1 = pic.create_canister().await;
-//     println!("First canister created, ID: {:?}", canister_id_1);
-
-//     pic.add_cycles(canister_id_1, 2_000_000_000_000).await;
-//     println!("Cycles added to the first canister");
-
-//     // Create the second canister
-//     let canister_id_2 = pic.create_canister().await;
-//     println!("Second canister created, ID: {:?}", canister_id_2);
-
-//     pic.add_cycles(canister_id_2, 2_000_000_000_000).await;
-//     println!("Cycles added to the second canister");
-
-//     // Install the WASM bytes on both canisters
-//     let wasm_path = std::env::var("EVM_LOGS_CANISTER_PATH")
-//         .expect("EVM_LOGS_CANISTER_PATH must be set");
-
-//     let wasm_bytes = tokio::fs::read(wasm_path)
-//         .await
-//         .expect("Failed to read the WASM file");
-
-//     pic.install_canister(canister_id_1, wasm_bytes.clone(), vec![], None).await;
-//     println!("Wasm installed in the first canister");
-
-//     pic.install_canister(canister_id_2, wasm_bytes.clone(), vec![], None).await;
-//     println!("Wasm installed in the second canister");
-
-//     // Define the first set of addresses and topics
-//     let addresses_to_monitor_1 = vec![
-//         "0x0d4a11d5eeaac28ec3f61d100daf4d40471f1852".to_string(),
-//     ];
-//     let topics_to_monitor_1 = vec![
-//         "0x0d4a11d5eeaac28ec3f61d100daf4d17f9k3v5h0".to_string(),
-//     ];
-
-//     // Define the second set of addresses and topics
-//     let addresses_to_monitor_2 = vec![
-//         "0x1d4a11d5eeaac28ec3f61d100daf4d40471f1854".to_string(),
-//     ];
-//     let topics_to_monitor_2 = vec![
-//         "0x2d4a11d5eeaac28ec3f61d100daf4d17f9k3v5h5".to_string(),
-//     ];
-
-//     // Register the first filter for the first canister
-//     let filter_string_1 = format!(
-//         r#"address == "{}" && topic == "{}""#,
-//         addresses_to_monitor_1[0], topics_to_monitor_1[0]
-//     );
-
-//     let filter_config_1 = vec![
-//         ICRC16Map {
-//             key: ICRC16Value::Text("icrc72:subscription:filter".to_string()),
-//             value: ICRC16Value::Text(filter_string_1),
-//         },
-//     ];
-
-//     let subscription_params_1 = SubscriptionRegistration {
-//         namespace: "test_namespace_filters_1".to_string(),
-//         config: filter_config_1,
-//         memo: None,
-//     };
-
-//     // Register the second filter for the second canister
-//     let filter_string_2 = format!(
-//         r#"address == "{}" && topic == "{}""#,
-//         addresses_to_monitor_2[0], topics_to_monitor_2[0]
-//     );
-
-//     let filter_config_2 = vec![
-//         ICRC16Map {
-//             key: ICRC16Value::Text("icrc72:subscription:filter".to_string()),
-//             value: ICRC16Value::Text(filter_string_2),
-//         },
-//     ];
-
-//     let subscription_params_2 = SubscriptionRegistration {
-//         namespace: "test_namespace_filters_2".to_string(),
-//         config: filter_config_2,
-//         memo: None,
-//     };
-
-//     // Call the registration function in the first canister
-//     println!("Calling subscription registration with filter in the first canister");
-//     let result_1 = pic.update_call(
-//         canister_id_1,
-//         Principal::anonymous(),
-//         "icrc72_register_subscription",
-//         candid::encode_one(vec![subscription_params_1.clone()]).unwrap(),
-//     ).await;
-
-//     // Call the registration function in the second canister
-//     println!("Calling subscription registration with filter in the second canister");
-//     let result_2 = pic.update_call(
-//         canister_id_2,
-//         Principal::anonymous(),
-//         "icrc72_register_subscription",
-//         candid::encode_one(vec![subscription_params_2.clone()]).unwrap(),
-//     ).await;
-
-//     // Check the result of the subscription registration for both canisters
-//     let check_subscription = |result: Result<WasmResult, pocket_ic::UserError>, expected_address: &str, expected_topic: &str| {
-//         match result {
-//             Ok(WasmResult::Reply(data)) => {
-//                 let decoded_result: Vec<RegisterSubscriptionResult> = candid::decode_one(&data).unwrap();
-                
-//                 match &decoded_result[0] {
-//                     RegisterSubscriptionResult::Ok(sub_id) => {
-//                         println!("Subscription successfully created, ID: {:?}", sub_id);
-//                     }
-//                     RegisterSubscriptionResult::Err(err) => {
-//                         panic!("Subscription registration error: {:?}", err);
-//                     }
-//                 }
-//             },
-//             Ok(WasmResult::Reject(err)) => {
-//                 panic!("Call was rejected: {:?}", err);
-//             }
-//             Err(e) => panic!("Call error: {:?}", e),
-//         }
-//     };
-
-//     check_subscription(result_1, &addresses_to_monitor_1[0], &topics_to_monitor_1[0]);
-//     check_subscription(result_2, &addresses_to_monitor_2[0], &topics_to_monitor_2[0]);
-
-//     // Now query the active filters for both canisters
-//     let filter_result_1 = pic.query_call(
-//         canister_id_1,
-//         Principal::anonymous(),
-//         "get_active_filters",
-//         candid::encode_args::<()>(()).unwrap(),
-//     ).await;
-
-//     let filter_result_2 = pic.query_call(
-//         canister_id_2,
-//         Principal::anonymous(),
-//         "get_active_filters",
-//         candid::encode_args::<()>(()).unwrap(),
-//     ).await;
-
-//     let check_filters = |filter_result: Result<WasmResult, pocket_ic::UserError>, expected_address: &str, expected_topic: &str| {
-//         match filter_result {
-//             Ok(WasmResult::Reply(data)) => {
-//                 let received_filters: Vec<Filter> = candid::decode_one(&data).unwrap();
-                
-//                 println!("\nActive filters for canister: ");
-//                 for (i, filter) in received_filters.iter().enumerate() {
-//                     println!("Filter {}:", i + 1);
-//                     println!("  Addresses: {:?}", filter.addresses);
-//                     if let Some(topics) = &filter.topics {
-//                         println!("  Topics: {:?}", topics);
-//                     } else {
-//                         println!("  Topics: None");
-//                     }
-//                 }
-
-//                 assert_eq!(received_filters.len(), 1, "Expected one filter");
-//                 assert_eq!(received_filters[0].addresses[0].trim_matches('"'), expected_address, "Incorrect filter address");
-                
-//                 if let Some(received_topic) = &received_filters[0].topics {
-//                     assert_eq!(
-//                         received_topic[0][0].trim_matches('"'),
-//                         expected_topic,
-//                         "Incorrect filter topics"
-//                     );
-//                 } else {
-//                     assert!(received_filters[0].topics.is_none(), "Unexpected topics in filter");
-//                 }
-//             },
-//             Ok(WasmResult::Reject(err)) => {
-//                 panic!("Call was rejected: {:?}", err);
-//             }
-//             Err(e) => panic!("Error querying filters: {:?}", e),
-//         }
-//     };
-
-//     check_filters(filter_result_1, &addresses_to_monitor_1[0], &topics_to_monitor_1[0]);
-//     check_filters(filter_result_2, &addresses_to_monitor_2[0], &topics_to_monitor_2[0]);
-
-//     // Reduced sleep time for testing purposes
-//     sleep(Duration::from_millis(500)).await;
-// }
-
-
-
-// // #[tokio::test]
-// // async fn test_publication_registration() {
-// //     // Initialize PocketIc
-// //     let pic = PocketIc::new().await;
-
-// //     // Create the subscription manager canister
-// //     let subscription_manager_canister_id = pic.create_canister().await;
-// //     pic.add_cycles(subscription_manager_canister_id, 2_000_000_000_000).await;
-
-// //     // Install the subscription manager wasm
-// //     let subscription_manager_wasm_path = std::env::var("EVM_LOGS_CANISTER_PATH")
-// //         .expect("EVM_LOGS_CANISTER_PATH must be set");
-// //     let subscription_manager_wasm_bytes = tokio::fs::read(subscription_manager_wasm_path)
-// //         .await
-// //         .expect("Failed to read the subscription manager WASM file");
-// //     pic.install_canister(
-// //         subscription_manager_canister_id,
-// //         subscription_manager_wasm_bytes.to_vec(),
-// //         vec![],
-// //         None,
-// //     )
-// //     .await;
-
-// //     // Register a publication
-// //     let publisher_principal = Principal::anonymous(); // Or a specific principal
-// //     let publication_registration = PublicationRegistration {
-// //         namespace: "test_namespace".to_string(),
-// //         config: vec![],
-// //         memo: None,
-// //     };
-// //     let register_publication_result = pic
-// //         .update_call(
-// //             subscription_manager_canister_id,
-// //             publisher_principal,
-// //             "call_register_publication",
-// //             candid::encode_one(vec![publication_registration.clone()]).unwrap(),
-// //         )
-// //         .await;
-
-// //     // Check the publication registration result
-// //     match register_publication_result {
-// //         Ok(WasmResult::Reply(data)) => {
-// //             let decoded_result: Vec<RegisterPublicationResult> = candid::decode_one(&data).unwrap();
-// //             match &decoded_result[0] {
-// //                 RegisterPublicationResult::Ok(pub_id) => {
-// //                     println!("Publication successfully created, ID: {:?}", pub_id);
-// //                     assert_ne!(*pub_id, Nat::from(0u32), "Publication ID should not be zero");
-// //                 }
-// //                 RegisterPublicationResult::Err(err) => {
-// //                     panic!("Publication registration error: {:?}", err);
-// //                 }
-// //             }
-// //         }
-// //         Ok(WasmResult::Reject(err)) => {
-// //             panic!("Publication registration rejected: {:?}", err);
-// //         }
-// //         Err(e) => {
-// //             panic!("Publication registration call error: {:?}", e);
-// //         }
-// //     }
-// // }
-
-// #[tokio::test]
-// async fn test_publication_registration() {
-//     let pic = PocketIc::new().await;
-
-//     let subscription_manager_canister_id = pic.create_canister().await;
-//     pic.add_cycles(subscription_manager_canister_id, 2_000_000_000_000).await;
-
-//     let subscription_manager_wasm_path = std::env::var("EVM_LOGS_CANISTER_PATH")
-//         .expect("EVM_LOGS_CANISTER_PATH must be set");
-//     let subscription_manager_wasm_bytes = tokio::fs::read(subscription_manager_wasm_path)
-//         .await
-//         .expect("Failed to read the subscription manager WASM file");
-//     pic.install_canister(
-//         subscription_manager_canister_id,
-//         subscription_manager_wasm_bytes.to_vec(),
-//         vec![],
-//         None,
-//     )
-//     .await;
-
-//     let publications = vec![
-//         PublicationRegistration {
-//             namespace: "test_namespace_1".to_string(),
-//             config: vec![],
-//             memo: None,
-//         },
-//         PublicationRegistration {
-//             namespace: "test_namespace_2".to_string(),
-//             config: vec![],
-//             memo: None,
-//         },
-//         PublicationRegistration {
-//             namespace: "test_namespace_3".to_string(),
-//             config: vec![],
-//             memo: None,
-//         },
-//     ];
-
-//     let publisher_principal = Principal::anonymous();
-//     let register_publication_result = pic
-//         .update_call(
-//             subscription_manager_canister_id,
-//             publisher_principal,
-//             "call_register_publication",
-//             candid::encode_one(publications.clone()).unwrap(),
-//         )
-//         .await;
-
-//     // Check the publication registration results
-//     match register_publication_result {
-//         Ok(WasmResult::Reply(data)) => {
-//             let decoded_results: Vec<RegisterPublicationResult> = candid::decode_one(&data).unwrap();
-
-//             assert_eq!(
-//                 decoded_results.len(),
-//                 publications.len(),
-//                 "Number of results should match number of publications"
-//             );
-
-//             // Collect the publication IDs
-//             let mut publication_ids = Vec::new();
-
-//             for (i, result) in decoded_results.iter().enumerate() {
-//                 match result {
-//                     RegisterPublicationResult::Ok(pub_id) => {
-//                         println!(
-//                             "Publication {} successfully created, ID: {:?}",
-//                             i + 1,
-//                             pub_id
-//                         );
-//                         assert_ne!(
-//                             pub_id,
-//                             &Nat::from(0u32),
-//                             "Publication ID should not be zero"
-//                         );
-
-//                         // Convert pub_id to String and collect, for future testing on uniqueness
-//                         publication_ids.push(pub_id.to_string());
-//                     }
-//                     RegisterPublicationResult::Err(err) => {
-//                         panic!("Publication registration error: {:?}", err);
-//                     }
-//                 }
-//             }
-
-//             // Check that all IDs are unique
-//             let unique_ids: HashSet<String> = publication_ids.iter().cloned().collect();
-
-//             assert_eq!(
-//                 unique_ids.len(),
-//                 publication_ids.len(),
-//                 "Publication IDs should be unique"
-//             );
-//         }
-//         Ok(WasmResult::Reject(err)) => {
-//             panic!("Publication registration rejected: {:?}", err);
-//         }
-//         Err(e) => {
-//             panic!("Publication registration call error: {:?}", e);
-//         }
-//     }
-// }
-
-
-// #[tokio::test]
-// async fn test_event_publishing() {
-//     let pic = PocketIc::new().await;
-
-//     let subscription_manager_canister_id = pic.create_canister().await;
-//     pic.add_cycles(subscription_manager_canister_id, 2_000_000_000_000).await;
-
-//     let subscription_manager_wasm_path = std::env::var("EVM_LOGS_CANISTER_PATH")
-//         .expect("EVM_LOGS_CANISTER_PATH must be set");
-//     let subscription_manager_wasm_bytes = tokio::fs::read(subscription_manager_wasm_path)
-//         .await
-//         .expect("Failed to read the subscription manager WASM file");
-//     pic.install_canister(
-//         subscription_manager_canister_id,
-//         subscription_manager_wasm_bytes.to_vec(),
-//         vec![],
-//         None,
-//     )
-//     .await;
-
-//     let publisher_principal = Principal::anonymous(); // Use appropriate principal
-//     let publication_registration = PublicationRegistration {
-//         namespace: "test_namespace".to_string(),
-//         config: vec![],
-//         memo: None,
-//     };
-//     let register_publication_result = pic
-//         .update_call(
-//             subscription_manager_canister_id,
-//             publisher_principal,
-//             "call_register_publication",
-//             candid::encode_one(vec![publication_registration.clone()]).unwrap(),
-//         )
-//         .await;
-
-//     let publication_id = match register_publication_result {
-//         Ok(WasmResult::Reply(data)) => {
-//             let decoded_results: Vec<RegisterPublicationResult> = candid::decode_one(&data).unwrap();
-//             match &decoded_results[0] {
-//                 RegisterPublicationResult::Ok(pub_id) => {
-//                     println!("Publication successfully created, ID: {:?}", pub_id);
-//                     assert_ne!(
-//                         *pub_id,
-//                         Nat::from(0u32),
-//                         "Publication ID should not be zero"
-//                     );
-//                     pub_id.clone()
-//                 }
-//                 RegisterPublicationResult::Err(err) => {
-//                     panic!("Publication registration error: {:?}", err);
-//                 }
-//             }
-//         }
-//         Ok(WasmResult::Reject(err)) => {
-//             panic!("Publication registration rejected: {:?}", err);
-//         }
-//         Err(e) => {
-//             panic!("Publication registration call error: {:?}", e);
-//         }
-//     };
-
-//     let events = vec![
-//         Event {
-//             id: Nat::from(0u64), 
-//             prev_id: None,
-//             timestamp: 0,
-//             namespace: "test_namespace".to_string(),
-//             data: ICRC16Value::Text("Test event data 1".to_string()),
-//             headers: None,
-//         },
-//         Event {
-//             id: Nat::from(0u64),
-//             prev_id: None,
-//             timestamp: 0,
-//             namespace: "test_namespace".to_string(),
-//             data: ICRC16Value::Text("Test event data 2".to_string()),
-//             headers: None,
-//         },
-//         Event {
-//             id: Nat::from(0u64),
-//             prev_id: None,
-//             timestamp: 0,
-//             namespace: "test_namespace".to_string(),
-//             data: ICRC16Value::Text("Test event data 3".to_string()),
-//             headers: None,
-//         },
-//     ];
-
-//     let publish_events_result = pic
-//         .update_call(
-//             subscription_manager_canister_id,
-//             publisher_principal,
-//             "icrc72_publish",
-//             candid::encode_one(events.clone()).unwrap(),
-//         )
-//         .await;
-
-//     match publish_events_result {
-//         Ok(WasmResult::Reply(data)) => {
-//             let decoded_results: Vec<Option<Result<Vec<Nat>, String>>> = candid::decode_one(&data).unwrap();
-//             assert_eq!(
-//                 decoded_results.len(),
-//                 events.len(),
-//                 "Number of results should match number of events"
-//             );
-
-//             let mut event_ids = Vec::new();
-
-//             for (i, result) in decoded_results.iter().enumerate() {
-//                 match result {
-//                     Some(Ok(event_id_vec)) => {
-//                         assert_eq!(
-//                             event_id_vec.len(),
-//                             1,
-//                             "Expected one event ID per event"
-//                         );
-//                         let event_id = &event_id_vec[0];
-//                         println!(
-//                             "Event {} published successfully, ID: {:?}",
-//                             i + 1,
-//                             event_id
-//                         );
-//                         assert_ne!(event_id, &Nat::from(0u32), "Event ID should not be zero");
-//                         event_ids.push(event_id.to_string());
-//                     }
-//                     Some(Err(err)) => {
-//                         panic!("Event publish error: {:?}", err);
-//                     }
-//                     None => {
-//                         panic!("Event publish returned None for event {}", i + 1);
-//                     }
-//                 }
-//             }
-
-//             let unique_event_ids: HashSet<String> = event_ids.iter().cloned().collect();
-//             assert_eq!(
-//                 unique_event_ids.len(),
-//                 event_ids.len(),
-//                 "Event IDs should be unique"
-//             );
-
-//         }
-//         Ok(WasmResult::Reject(err)) => {
-//             panic!("Event publish rejected: {:?}", err);
-//         }
-//         Err(e) => {
-//             panic!("Event publish call error: {:?}", e);
-//         }
-//     }
-// }
-
-
-
-// #[tokio::test]
-// async fn test_event_publishing_and_notification_delivery() {
-//     let pic = PocketIc::new().await;
-
-//     let subscription_manager_canister_id = pic.create_canister().await;
-//     pic.add_cycles(subscription_manager_canister_id, 2_000_000_000_000).await;
-
-//     let subscription_manager_wasm_path = std::env::var("EVM_LOGS_CANISTER_PATH")
-//         .expect("EVM_LOGS_CANISTER_PATH must be set");
-//     let subscription_manager_wasm_bytes = tokio::fs::read(subscription_manager_wasm_path)
-//         .await
-//         .expect("Failed to read the subscription manager WASM file");
-//     pic.install_canister(
-//         subscription_manager_canister_id,
-//         subscription_manager_wasm_bytes.to_vec(),
-//         vec![],
-//         None,
-//     )
-//     .await;
-
-//     // Create the subscriber canister
-//     let subscriber_canister_id = pic.create_canister().await;
-//     pic.add_cycles(subscriber_canister_id, 2_000_000_000_000).await;
-
-//     // Install the subscriber wasm
-//     let subscriber_wasm_path = std::env::var("TEST_CANISTER_WASM_PATH")
-//         .expect("TEST_CANISTER_WASM_PATH must be set");
-//     let subscriber_wasm_bytes = tokio::fs::read(subscriber_wasm_path)
-//         .await
-//         .expect("Failed to read the subscriber WASM file");
-//     pic.install_canister(
-//         subscriber_canister_id,
-//         subscriber_wasm_bytes.to_vec(),
-//         vec![],
-//         None,
-//     )
-//     .await;
-
-//     // Register a subscription from the subscriber canister
-//     let subscription_registration = SubscriptionRegistration {
-//         namespace: "test_namespace".to_string(),
-//         config: vec![],
-//         memo: None,
-//     };
-//     let register_subscription_result = pic
-//         .update_call(
-//             subscription_manager_canister_id,
-//             subscriber_canister_id, 
-//             "icrc72_register_subscription",
-//             candid::encode_one(vec![subscription_registration.clone()]).unwrap(),
-//         )
-//         .await;
-
-//     // Check the subscription registration result
-//     match register_subscription_result {
-//         Ok(WasmResult::Reply(data)) => {
-//             let decoded_result: Vec<RegisterSubscriptionResult> = candid::decode_one(&data).unwrap();
-//             match &decoded_result[0] {
-//                 RegisterSubscriptionResult::Ok(sub_id) => {
-//                     println!("Subscription successfully created, ID: {:?}", sub_id);
-//                 }
-//                 RegisterSubscriptionResult::Err(err) => {
-//                     panic!("Subscription registration error: {:?}", err);
-//                 }
-//             }
-//         }
-//         Ok(WasmResult::Reject(err)) => {
-//             panic!("Subscription registration rejected: {:?}", err);
-//         }
-//         Err(e) => {
-//             panic!("Subscription registration call error: {:?}", e);
-//         }
-//     }
-
-//     // Register a publication
-//     let publisher_principal = Principal::anonymous(); 
-//     let publication_registration = PublicationRegistration {
-//         namespace: "test_namespace".to_string(),
-//         config: vec![],
-//         memo: None,
-//     };
-//     let register_publication_result = pic
-//         .update_call(
-//             subscription_manager_canister_id,
-//             publisher_principal,
-//             "call_register_publication",
-//             candid::encode_one(vec![publication_registration.clone()]).unwrap(),
-//         )
-//         .await;
-
-//     // Check the publication registration result
-//     match register_publication_result {
-//         Ok(WasmResult::Reply(data)) => {
-//             let decoded_result: Vec<RegisterPublicationResult> = candid::decode_one(&data).unwrap();
-//             match &decoded_result[0] {
-//                 RegisterPublicationResult::Ok(pub_id) => {
-//                     println!("Publication successfully created, ID: {:?}", pub_id);
-//                 }
-//                 RegisterPublicationResult::Err(err) => {
-//                     panic!("Publication registration error: {:?}", err);
-//                 }
-//             }
-//         }
-//         Ok(WasmResult::Reject(err)) => {
-//             panic!("Publication registration rejected: {:?}", err);
-//         }
-//         Err(e) => {
-//             panic!("Publication registration call error: {:?}", e);
-//         }
-//     }
-
-//     // Publish an event
-//     let event = Event {
-//         id: Nat::from(0u64), // ID will be assigned by the canister
-//         prev_id: None,
-//         timestamp: 0,
-//         namespace: "test_namespace".to_string(),
-//         data: ICRC16Value::Text("Test event data".to_string()),
-//         headers: None,
-//     };
-//     let publish_events_result = pic
-//         .update_call(
-//             subscription_manager_canister_id,
-//             publisher_principal,
-//             "icrc72_publish",
-//             candid::encode_one(vec![event.clone()]).unwrap(),
-//         )
-//         .await;
-
-//     // Check the event publishing result
-//     match publish_events_result {
-//         Ok(WasmResult::Reply(data)) => {
-//             let decoded_results: Vec<Option<Result<Vec<Nat>, String>>> = candid::decode_one(&data).unwrap();
-//             match &decoded_results[0] {
-//                 Some(Ok(event_ids)) => {
-//                     println!("Event published successfully, IDs: {:?}", event_ids);
-//                     assert_eq!(event_ids.len(), 1, "Expected one event ID");
-//                     assert_ne!(event_ids[0], Nat::from(0u32), "Event ID should not be zero");
-//                 }
-//                 Some(Err(err)) => {
-//                     panic!("Event publish error: {:?}", err);
-//                 }
-//                 None => {
-//                     panic!("Event publish returned None");
-//                 }
-//             }
-//         }
-//         Ok(WasmResult::Reject(err)) => {
-//             panic!("Event publish rejected: {:?}", err);
-//         }
-//         Err(e) => {
-//             panic!("Event publish call error: {:?}", e);
-//         }
-//     }
-
-//     // Wait for the notification to be sent
-//     sleep(Duration::from_millis(500)).await;
-
-//     // Query the subscriber canister to retrieve notifications
-//     let get_notifications_result = pic
-//         .query_call(
-//             subscriber_canister_id,
-//             Principal::anonymous(),
-//             "get_notifications",
-//             candid::encode_args(()).unwrap(),
-//         )
-//         .await;
-
-//     // Verify that the subscriber received the notification
-//     match get_notifications_result {
-//         Ok(WasmResult::Reply(data)) => {
-//             let notifications: Vec<EventNotification> = candid::decode_one(&data).unwrap();
-//             println!("Received notifications: {:?}", notifications);
-//             assert_eq!(notifications.len(), 1, "Expected one notification");
-//             let notification = &notifications[0];
-//             assert_eq!(notification.namespace, "test_namespace", "Incorrect namespace");
-//             if let ICRC16Value::Text(ref text) = notification.data {
-//                 assert_eq!(text, "Test event data", "Incorrect event data");
-//             } else {
-//                 panic!("Unexpected data type in notification");
-//             }
-//         }
-//         Ok(WasmResult::Reject(err)) => {
-//             panic!("Get notifications rejected: {:?}", err);
-//         }
-//         Err(e) => {
-//             panic!("Get notifications call error: {:?}", e);
-//         }
-//     }
-// }


### PR DESCRIPTION
This changes implement filtering by Ethereum (EVM) log topics. The Filter structure now includes topics, which allows specifying more detailed filters for events based on the topics in the Ethereum logs.

### Strategy of EVM Topics Passing:
When sending a filter to the EVM node, you can specify which log topics should match specific positions in the event. Here’s how the topic filters work:

- [] (empty): Matches any transaction, as no specific topics are required.
- [A]: Matches if the first topic of the transaction is A, with no restrictions on the following topics.
- [null, B]: Matches any transaction with B in the second position, regardless of the first topic.
- [A, B]: Matches transactions where A is in the first position and B is in the second.
- [[A, B], [A, B]]: Matches if the first topic is either A or B, and the second topic is also either A or B. This creates an "OR" condition for each position.