### PR TITLE
Proxy canister introduced for events sending

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
     "evm_logs_types",
     "src/canister_testing/test_canister1",
     "src/canister_testing/test_canister2",
+    "src/proxy",
 ]
 
 [package]

--- a/dfx.json
+++ b/dfx.json
@@ -46,6 +46,18 @@
           "value": "src/test_canister2/test_canister.did"
         }
       ]
+    },
+    "proxy_canister": {
+      "type": "custom",
+      "wasm": "target/wasm32-unknown-unknown/release/proxy_canister.wasm",
+      "candid": "src/proxy/proxy_canister.did",
+      "build": "cargo build --target wasm32-unknown-unknown --release --package proxy_canister",
+      "metadata": [
+        {
+          "name": "candid:service",
+          "value": "src/proxy_canister/proxy_canister.did"
+        }
+      ]
     }
   },
   "version": 1

--- a/src/proxy/Cargo.toml
+++ b/src/proxy/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "proxy_canister"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+name = "proxy_canister"
+crate-type = ["cdylib"]
+
+[dependencies]
+ic-cdk = "0.14.0"
+ic-cdk-macros = "0.9"
+candid = "0.10"
+serde = "1.0"
+serde_bytes = "0.11"
+evm_logs_types = { path = "../../evm_logs_types" } 

--- a/src/proxy/proxy_canister.did
+++ b/src/proxy/proxy_canister.did
@@ -1,0 +1,23 @@
+type Filter = record {
+    address: text;
+    topics: opt vec vec text;
+};
+
+type EventNotification = record {
+  sub_id : nat;
+  event_id : nat;
+  event_prev_id : opt nat;
+  timestamp : nat64;
+  namespace : text;
+  data : vec nat8;
+  tx_hash : opt text;
+  headers : vec record { text; text };
+  topics : vec text;
+  source : principal;
+  filter : opt Filter;
+};
+
+service : {
+  send_notification : (principal, EventNotification) -> (variant { Ok; Err : text });
+  __get_candid_interface_tmp_hack : () -> (text) query;
+}

--- a/src/proxy/src/lib.rs
+++ b/src/proxy/src/lib.rs
@@ -1,0 +1,35 @@
+use candid::{candid_method, Principal};
+use ic_cdk::api::call::call;
+use std::vec::Vec;
+use evm_logs_types::EventNotification;
+use ic_cdk_macros::{query, update};
+
+
+#[update(name = "send_notification")]
+#[candid_method(update)]
+async fn send_notification(
+    subscriber: Principal,
+    notification: EventNotification,
+) -> Result<(), String> {
+    ic_cdk::println!("Calling handle_notification");
+    // Send the notification to the subscriber
+    // TODO propagate error to evm-logs-canister? handle error correctly
+    let result: Result<(), String> = call(
+        subscriber,
+        "handle_notification",
+        (notification.clone(),),
+    )
+    .await
+    .map_err(|e| format!("Failed to send notification: {:?}", e));
+
+
+    Ok(())
+}
+
+#[query]
+fn get_candid_pointer() -> String {
+    __export_service()
+}
+
+candid::export_service!();
+


### PR DESCRIPTION
Proxy canister introduced to avoid [DoS issues](https://internetcomputer.org/docs/current/developer-docs/security/security-best-practices/inter-canister-calls#be-aware-of-the-risks-involved-in-calling-untrustworthy-canisters) with callback mechanics (publish to subscriber).